### PR TITLE
Category board view

### DIFF
--- a/TipPlace/TipPlace/CategoryBoard/CategoryBoardView.swift
+++ b/TipPlace/TipPlace/CategoryBoard/CategoryBoardView.swift
@@ -76,7 +76,7 @@ struct CategoryBoardView: View {
 
 struct CategoryBoardView_Previews: PreviewProvider {
     static var previews: some View {
-        CategoryBoardView(categoryEnum: Category.livingAlone, queryString: "")
+        CategoryBoardView(categoryEnum: Category.companionLife, queryString: "")
     }
 }
 

--- a/TipPlace/TipPlace/ModelData/MockData.swift
+++ b/TipPlace/TipPlace/ModelData/MockData.swift
@@ -252,7 +252,7 @@ struct UserInfoMock{
                               usefulPost: [57],
                               replyPost: [53, 54, 55],
                               markPost: nil,
-                              writtendPost: [53],
+                              writtendPost: [53, 54],
                               interestedTag: ["강아지", "산책", "반려동물"],
                               interestedCategory: [Category.companionLife, Category.cook, Category.health])
     static var userInfo54 = UserInfo(id: 54,

--- a/TipPlace/TipPlace/MyPageChildrenView/ExpertCollectionView.swift
+++ b/TipPlace/TipPlace/MyPageChildrenView/ExpertCollectionView.swift
@@ -17,7 +17,7 @@ struct ExpertSelectButtonView: View {
         VStack(alignment: .leading) {
             Button {
             } label: {
-                NavigationLink(destination: ExpertProfileView()) {
+                NavigationLink(destination: ExpertProfileView(userId: userId)) {
                     VStack {
                         ProfileImageView()
                             .aspectRatio(contentMode: .fit)

--- a/TipPlace/TipPlace/MyPageChildrenView/ExpertProfileView.swift
+++ b/TipPlace/TipPlace/MyPageChildrenView/ExpertProfileView.swift
@@ -35,8 +35,8 @@ struct ExpertProfileView: View {
     }
     var body: some View {
         VStack(alignment: .leading) {
-            ExpertInfoView(userId:userId)
-            ExpertPostsView(userId:userId)
+            ExpertInfoView(userId: userId)
+            ExpertPostsView(userId: userId)
             Spacer()
         }
             .navigationBarBackButtonHidden(true)
@@ -91,8 +91,9 @@ struct ExpertInfoView: View {
 struct ExpertPostsView: View {
     var userId: Int
     var body: some View {
-        VStack {
-            Text("보드리스트가 들어올 곳")
+        List {
+            BoardListView(boardPostsList: ListMock.boardPosts.filter({$0.author.id == userId}))
+//            일단 작성글/유용한 글/북마크 구별 없이 보드 배치
         }
     }
 }

--- a/TipPlace/TipPlace/MyPageChildrenView/ExpertProfileView.swift
+++ b/TipPlace/TipPlace/MyPageChildrenView/ExpertProfileView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ExpertProfileView: View {
+    var userId: Int
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     var backButton : some View {
         Button {
@@ -34,8 +35,8 @@ struct ExpertProfileView: View {
     }
     var body: some View {
         VStack(alignment: .leading) {
-            ExpertInfoView()
-            ExpertPostsView()
+            ExpertInfoView(userId:userId)
+            ExpertPostsView(userId:userId)
             Spacer()
         }
             .navigationBarBackButtonHidden(true)
@@ -46,6 +47,7 @@ struct ExpertProfileView: View {
 }
 
 struct ExpertInfoView: View {
+    var userId: Int
     var body: some View {
         VStack {
             ProfileImageView()
@@ -85,6 +87,7 @@ struct ExpertInfoView: View {
 }
 
 struct ExpertPostsView: View {
+    var userId: Int
     var body: some View {
         VStack {
             Text("보드리스트가 들어올 곳")
@@ -94,6 +97,6 @@ struct ExpertPostsView: View {
 
 struct ExpertProfileView_Previews: PreviewProvider {
     static var previews: some View {
-        ExpertProfileView()
+        ExpertProfileView(userId: 1)
     }
 }

--- a/TipPlace/TipPlace/MyPageChildrenView/ExpertProfileView.swift
+++ b/TipPlace/TipPlace/MyPageChildrenView/ExpertProfileView.swift
@@ -49,34 +49,36 @@ struct ExpertProfileView: View {
 struct ExpertInfoView: View {
     var userId: Int
     var body: some View {
+        let user: UserInfo = loadUser(userId: userId)
         VStack {
             ProfileImageView()
                 .padding(EdgeInsets(top: 40, leading: 0, bottom: 10, trailing: 0))
-            Text("아이디")
+            Text(user.name)
             .font(.system(size: 21, weight: .regular))
             .padding(EdgeInsets(top: 0, leading: 0, bottom: 10, trailing: 0))
-            Text("카테고리")
+            Text(user.speficalDomain?[0].korean ?? "디폴트 카테고리")
             .font(.system(size: 15, weight: .regular))
             .foregroundColor(.green)
             .padding(EdgeInsets(top: 0, leading: 0, bottom: 4, trailing: 0))
-            Text("#태그 #태그 #태그")
+            Text(loadTag(userId: userId)[0])
+//            배열 내 문자열을 일렬로 출력하는 방법 필요
             .font(.system(size: 12, weight: .regular))
             HStack {
                 VStack {
-                    Text("3")
+                    Text(String(user.writtendPost?.count ?? 0))
                         .font(.system(size: 25, weight: .bold))
                     Text("게시물")
                         .font(.system(size: 12, weight: .regular))
                 }
                 VStack {
-                    Text("3")
+                    Text(String(user.replyPost?.count ?? 0))
                         .font(.system(size: 25, weight: .bold))
                     Text("유용해요")
                         .font(.system(size: 12, weight: .regular))
                 }
                 .padding(EdgeInsets(top: 30, leading: 70, bottom: 30, trailing: 70))
                 VStack {
-                    Text("3")
+                    Text(String(user.markPost?.count ?? 0))
                         .font(.system(size: 25, weight: .bold))
                     Text("저장")
                         .font(.system(size: 12, weight: .regular))

--- a/TipPlace/TipPlace/Utility/loadTag.swift
+++ b/TipPlace/TipPlace/Utility/loadTag.swift
@@ -11,9 +11,8 @@ func loadTag(userId: Int) -> [String] {
     let user: UserInfo = loadUser(userId: userId)
     if let tags: [String] = user.interestedTag {
         return tags
-    } else
-    {
-        return ["tmp tag"]
-        
+    } else {
+        return [""]
+//        빈 문자열로 변경
     }
 }


### PR DESCRIPTION
# 카테고리 보드 뷰의 전문가 뷰로 파라미터 전달

* 사이먼과 협업해 전문가 셀렉트 버튼 뷰에 뜨는 프리뷰 에러를 수정했습니다
* 전문가 글 선택 시 유저 아이디를 파라미터로 넘겨 해당 유저 정보 및 관련 게시물을 로드하는 것까지 구현했습니다.

----
해야 할 과제는 다음과 같은 것들... 같습니다.
1. Url을 넘겨줄 때 디폴트 이미지 설정하기 (널 값 또는 빈 값이면?)
2. 전문가 프로필 뷰에서 네비게이션 바에 위치한 전문가 정보가 네비게이션 바에 고정이 되어 있어 게시물을 스크롤하는 공간이 부족한 것 같습니다. 섹션으로 추후 분리가 필요할 듯합니다.
3. 전문가 프로필 뷰에서 쓴 글 / 유용해요 누른 글 / 북마크 한 글을 버튼 별로 분리해 해당 보드가 뜨도록 해야 하는데, 바인딩을 사용해서 처리할 것 같습니다.
4. 전문가 프로필 뷰가 아니라 전문가 그리드 뷰에서 카테고리 별로 전문가를 선택해오는 데, 이때 선택하는 카테고리는 현재 로그인한 유저가 관심 있는 카테고리와 일치하는 전문가 목록일 듯합니다. 그런데 현재 저희 구현 상태에서는 로그인을 상정하지 않았기 때문에, 현 구현에서 어떤 식으로 표현할지 물어보고자 합니다. 또한 흥미 카테고리가 1개 이상이면 추천해주는 (즉 그리드 버튼으로 나타내줄) 전문가는 이 모든 카테고리와 일치하는 전문가를 불러오는 것 맞나요? 